### PR TITLE
Update ImageBrowser.js

### DIFF
--- a/src/ImageBrowser.js
+++ b/src/ImageBrowser.js
@@ -8,7 +8,13 @@ import {
   Dimensions,
   Button
 } from 'react-native';
+/*
+EXPO SDK 35 doesnt work with this mport format of the FileSystem module , I have updated it
 import { FileSystem } from 'expo';
+
+*/
+import * as FileSystem from 'expo-file-system';
+
 import ImageTile from './ImageTile';
 const { width } = Dimensions.get('window')
 


### PR DESCRIPTION
EXPO SDK 35 doesnt work with this import format of the FileSystem module , I have updated it from "import { FileSystem } from 'expo'; " to "import * as FileSystem from 'expo-file-system';"